### PR TITLE
57 [🩹] DM 보낼떄 createdAt 보내기

### DIFF
--- a/src/events/events.gateway.ts
+++ b/src/events/events.gateway.ts
@@ -147,22 +147,29 @@ export class DMGateway implements OnGatewayConnection, OnGatewayDisconnect {
           ? { id: users[0]['id'], nickname: users[0]['nickname'] }
           : { id: users[1]['id'], nickname: users[1]['nickname'] };
 
-      // const contentUrl = data.content ? fileUpload(data.content) : null;
+      const now = new Date();
+
       await this.chattingsRepository.insert({
         message: data.message,
         contentUrl: '',
         SenderId: sender.id,
         ReceiverId: receiver.id,
         RoomId: socket.nsp.name.substring(4, socket.nsp.name.length),
-        createdAt: new Date(),
+        createdAt: now,
       });
 
-      socket.emit('newDM', { ...data, sender: sender, receiver: receiver });
+      socket.emit('newDM', {
+        ...data,
+        sender: sender,
+        receiver: receiver,
+        createdAt: now,
+      });
 
       socket.broadcast.emit('newDM', {
         ...data,
         sender: sender,
         receiver: receiver,
+        createdAt: now,
       });
     } catch (error) {
       Logger.error(error.message, 'DM');

--- a/src/posts/services/posts.service.ts
+++ b/src/posts/services/posts.service.ts
@@ -289,7 +289,7 @@ export class PostsService {
         : [];
 
       return {
-        postid: onePost.id,
+        postId: onePost.id,
         nickname: onePost.User.nickname,
         profileUrl: onePost.User['File']['contentUrl'],
         title: onePost.title,


### PR DESCRIPTION
### 개요

- DM 보낼떄 createdAt 안보내던것 수정
- 게시글 상세 조회 postId 를 postid라고 보내던것 수정

### 작업사항

- DM 보낼떄 createdAt 안보내던것 수정
- 게시글 상세 조회 postId 를 postid라고 보내던것 수정
### 변경사항

- posts.service.ts
- event.gateway.ts

### Issue 번호

- #57