### PR TITLE
118 [🐛] 프로필 이미지 설정 안한 유저가 홈프로필 조회시 500번 에러 발생

### DIFF
--- a/src/profile/profile.service.ts
+++ b/src/profile/profile.service.ts
@@ -105,7 +105,7 @@ export class ProfileService {
       {
         user: {
           nickname: userData.nickname,
-          contentUrl: userData.File['contentUrl'],
+          contentUrl: userData.File ? userData.File['contentUrl'] : '',
         },
       },
       { dogs: allDogsData },
@@ -170,7 +170,7 @@ export class ProfileService {
       {
         user: {
           nickname: userData.nickname,
-          contentUrl: userData.File['contentUrl'],
+          contentUrl: userData.File ? userData.File['contentUrl'] : '',
           introduce: userData.introduce,
           dogsCount: allDogs.length,
         },


### PR DESCRIPTION
### 개요

- Home Profile , Profile 조회시 ContentUrl이 없는 유저를 조회시 500번 에러 발생 하는 부분 수정.


### 작업사항

- Home Profile , Profile 조회시 ContentUrl이 없는 유저를 조회시 500번 에러 발생 하는 부분 수정.


### 변경사항

- profile.service.ts

### Issue 번호

- #118